### PR TITLE
[VID-289] - CLI recorder webcam background is set to pink when 125% scaling

### DIFF
--- a/libobs-sharp/src/ObsDisplay.cs
+++ b/libobs-sharp/src/ObsDisplay.cs
@@ -1,4 +1,4 @@
-﻿/***************************************************************************
+/***************************************************************************
 	Copyright (C) 2014-2015 by Ari Vuollet <ari.vuollet@kapsi.fi>
 
 	This program is free software; you can redistribute it and/or
@@ -31,7 +31,7 @@ namespace OBS
 
 		public ObsDisplay(libobs.gs_init_data graphicsData)
 		{
-			instance = libobs.obs_display_create(ref graphicsData);
+			instance = libobs.obs_display_create(ref graphicsData, 0);
 
 			if (instance == null)
 				throw new ApplicationException("obs_display_create failed");

--- a/libobs-sharp/src/libobs/libobs/display.cs
+++ b/libobs-sharp/src/libobs/libobs/display.cs
@@ -30,7 +30,7 @@ namespace OBS
 		/* Display context */
 
 		[DllImport(importLibrary, CallingConvention = importCall)]
-		public static extern obs_display_t obs_display_create(ref gs_init_data graphics_data);
+		public static extern obs_display_t obs_display_create(ref gs_init_data graphics_data, uint32_t background_color);
 
 		[DllImport(importLibrary, CallingConvention = importCall)]
 		public static extern void obs_display_destroy(obs_display_t display);


### PR DESCRIPTION
in this pr:

- set the webcam display item's background to black so the filler isn't as obvious